### PR TITLE
Added IDs, guid gen, tests

### DIFF
--- a/src/main/com/cqfn/degitx/simulator/Address.kt
+++ b/src/main/com/cqfn/degitx/simulator/Address.kt
@@ -18,6 +18,7 @@ class Address(address : String) {
      */
     val addr = address
 
+    //TODO: Change to call GUID
     companion object {
         val randomAddr = Random().ints(addressLength, 0, source.length)
                 .asSequence()

--- a/src/main/com/cqfn/degitx/simulator/Edge.kt
+++ b/src/main/com/cqfn/degitx/simulator/Edge.kt
@@ -1,11 +1,16 @@
 package com.cqfn.degitx.simulator
 
+import com.cqfn.degitx.simulator.randomengine.GUID
+
 /**
  * Represents the record in routing table.
  * Global routing table is represented here by Graph class.
  * @see Graph
  */
 class Edge {
+
+    var id = GUID().guid
+
     constructor(tail: Server, head: Server) {
         this.head = head
         this.tail = tail

--- a/src/main/com/cqfn/degitx/simulator/GraphGenerator.kt
+++ b/src/main/com/cqfn/degitx/simulator/GraphGenerator.kt
@@ -1,5 +1,6 @@
 package com.cqfn.degitx.simulator
 
+import com.cqfn.degitx.simulator.randomengine.GUID
 import java.util.*
 
 /**
@@ -26,13 +27,13 @@ class GraphGenerator{
      */
     fun generate(settings: Settings) : DsGraph {
         for (i in 1..settings.nodeNumber) {
-            var node = Node(NodeHardware(SATAStorage(),
+            var node = Node(GUID().guid, NodeHardware(SATAStorage(),
                     BasicNetwork(Address("node"+i), LinkedList(), 1L)),
                     State.ACTIVE)
             nodes = nodes.plus(node)
         }
         for (i in 1..settings.routersNumber) {
-            var router = Router(NodeHardware(null,
+            var router = Router(GUID().guid, NodeHardware(null,
                     BasicNetwork(Address("node"+(settings.nodeNumber+i).toString()), LinkedList(), 1L)),
                     State.ACTIVE)
             nodes = nodes.plus(router)

--- a/src/main/com/cqfn/degitx/simulator/Node.kt
+++ b/src/main/com/cqfn/degitx/simulator/Node.kt
@@ -1,5 +1,7 @@
 package com.cqfn.degitx.simulator
 
+import com.cqfn.degitx.simulator.randomengine.GUID
+
 /**
  * Physical Server with GitHub repositories (Node) representation.
  * As part of global networks connected with other Nodes via Edges.
@@ -7,12 +9,18 @@ package com.cqfn.degitx.simulator
  * @see Graph
  * @see Edge
  */
-class Node(override var hardware: Hardware,
-           override var state: State) : Server {
+class Node(override var hardware: Hardware) : Server {
+
+    override var id = GUID().guid
+
+    override var state = State.ACTIVE
 
     var processedRqs = mutableSetOf<Int>()
 
-    constructor(hw: Hardware): this(hw, State.ACTIVE)
+    constructor(id: String, hw: Hardware, state: State): this(hw) {
+        this.id = id
+        this.state = state
+    }
 
     /**
      * Logic of software GitHub Node

--- a/src/main/com/cqfn/degitx/simulator/Router.kt
+++ b/src/main/com/cqfn/degitx/simulator/Router.kt
@@ -1,5 +1,7 @@
 package com.cqfn.degitx.simulator
 
+import com.cqfn.degitx.simulator.randomengine.GUID
+
 /**
  * Smart Router representation.
  * As part of global networks connected with other Servers via Edges.
@@ -8,12 +10,19 @@ package com.cqfn.degitx.simulator
  * @see Graph
  * @see Edge
  */
-class Router(override var hardware: Hardware,
-             override var state: State) : Server {
+class Router(override var hardware: Hardware) : Server {
 
-    constructor(hw: Hardware): this(hw, State.ACTIVE)
+    override var id = GUID().guid
+
+    override var state = State.ACTIVE
 
     var processedRqs = mutableSetOf<Int>()
+
+    constructor(id: String, hw: Hardware, state: State): this(hw) {
+        this.id = id
+        this.state = state
+    }
+
 
     /**
      * Logic of software or hardware Router

--- a/src/main/com/cqfn/degitx/simulator/Server.kt
+++ b/src/main/com/cqfn/degitx/simulator/Server.kt
@@ -6,6 +6,11 @@ package com.cqfn.degitx.simulator
  */
 interface Server {
     /**
+     * Unique ID of the Server
+     */
+    var id: String
+
+    /**
      * Storage if any and one network adapter
      */
     var hardware: Hardware

--- a/src/main/com/cqfn/degitx/simulator/randomengine/GUID.kt
+++ b/src/main/com/cqfn/degitx/simulator/randomengine/GUID.kt
@@ -3,10 +3,20 @@ package com.cqfn.degitx.simulator.randomengine
 import java.util.*
 import kotlin.streams.asSequence
 
+/**
+ * Extended set of Symbols to generate alpha-numeric sequences.
+ */
 const val longSource = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
+/**
+ * Pre-defined length for Graph entities IDs.
+ */
 const val GUIDLength = 8L
 
+/**
+ * Common class instead of static String util to generate IDs or any Random String sequences.
+ * Call w/o parameters: GUID().guid
+ */
 class GUID {
     val guid = Random().ints(GUIDLength, 0, longSource.length)
             .asSequence()

--- a/src/main/com/cqfn/degitx/simulator/randomengine/GUID.kt
+++ b/src/main/com/cqfn/degitx/simulator/randomengine/GUID.kt
@@ -1,0 +1,15 @@
+package com.cqfn.degitx.simulator.randomengine
+
+import java.util.*
+import kotlin.streams.asSequence
+
+const val longSource = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+const val GUIDLength = 8L
+
+class GUID {
+    val guid = Random().ints(GUIDLength, 0, longSource.length)
+            .asSequence()
+            .map(longSource::get)
+            .joinToString("")
+}

--- a/src/test/com/cqfn/degitx/simulator/GraphGeneratorTest.kt
+++ b/src/test/com/cqfn/degitx/simulator/GraphGeneratorTest.kt
@@ -1,5 +1,6 @@
 package com.cqfn.degitx.simulator
 
+import com.cqfn.degitx.simulator.randomengine.GUIDLength
 import org.testng.annotations.Test
 
 import org.testng.Assert.*
@@ -22,5 +23,14 @@ class GraphGeneratorTest {
         assertEquals(DsGraph.edges.size, 6)
         assertEquals(DsGraph.outgoingEdges(DsGraph.nodes[0]).size, 1)
         assertEquals(DsGraph.incomingEdges(DsGraph.nodes[0]).size, 3)
+    }
+
+    @Test
+    fun checkIDs() {
+        println(this.javaClass.name + ": checkIDs")
+        assertEquals(DsGraph.nodes[0].id.length.toLong(), GUIDLength)
+        println(DsGraph.nodes[0].id)
+        assertEquals(DsGraph.edges[0].id.length.toLong(), GUIDLength)
+        println(DsGraph.edges[0].id)
     }
 }

--- a/src/test/com/cqfn/degitx/simulator/RequestPathTest.kt
+++ b/src/test/com/cqfn/degitx/simulator/RequestPathTest.kt
@@ -1,7 +1,6 @@
 package com.cqfn.degitx.simulator
 
 import org.testng.Assert
-import org.testng.annotations.BeforeTest
 import org.testng.annotations.Test
 
 
@@ -9,13 +8,10 @@ class RequestPathTest {
 
     private var graph = GraphGenerator()
 
-    @BeforeTest
-    fun setUp() {
-        graph.generate(GraphGenerator.Settings())
-    }
-
     @Test
     fun requestGoesToTarget() {
+        graph.generate(GraphGenerator.Settings())
+
         var rq = Request(Address("node1"), Address("node2"),
                 1, 123L, 0L, Request.Type.WRITE)
         graph.nodes[1].run(rq)

--- a/src/test/com/cqfn/degitx/simulator/RouterTest.kt
+++ b/src/test/com/cqfn/degitx/simulator/RouterTest.kt
@@ -1,16 +1,15 @@
 package com.cqfn.degitx.simulator
 
-import org.testng.Assert
 import org.testng.annotations.Test
 
 import org.testng.Assert.*
-import org.testng.annotations.BeforeTest
+import org.testng.annotations.BeforeSuite
 
 class RouterTest {
 
     var graph = GraphGenerator()
 
-    @BeforeTest
+    @BeforeSuite
     fun setUp() {
         graph.generate(GraphGenerator.Settings())
     }

--- a/src/test/com/cqfn/degitx/simulator/data/GraphDataTest.kt
+++ b/src/test/com/cqfn/degitx/simulator/data/GraphDataTest.kt
@@ -25,7 +25,6 @@ class GraphDataTest {
 
     @Test
     fun witeStaticGraph() {
-        // graph.generate(GraphGenerator.Settings())
         var grData = Gson().toJson(graph)
         println(grData)
     }

--- a/src/test/com/cqfn/degitx/simulator/data/GraphDataTest.kt
+++ b/src/test/com/cqfn/degitx/simulator/data/GraphDataTest.kt
@@ -2,12 +2,18 @@ package com.cqfn.degitx.simulator.data
 
 import com.cqfn.degitx.simulator.GraphGenerator
 import com.google.gson.Gson
+import org.testng.annotations.BeforeSuite
 import org.testng.annotations.Test
 import java.io.File
 
 class GraphDataTest {
 
     var graph = GraphGenerator()
+
+    @BeforeSuite
+    fun setUp() {
+        graph.generate(GraphGenerator.Settings())
+    }
 
     @Test
     fun testTestToString() {
@@ -19,7 +25,7 @@ class GraphDataTest {
 
     @Test
     fun witeStaticGraph() {
-        graph.generate(GraphGenerator.Settings())
+        // graph.generate(GraphGenerator.Settings())
         var grData = Gson().toJson(graph)
         println(grData)
     }

--- a/src/test/com/cqfn/degitx/simulator/randomengine/GUIDTest.kt
+++ b/src/test/com/cqfn/degitx/simulator/randomengine/GUIDTest.kt
@@ -1,0 +1,12 @@
+package com.cqfn.degitx.simulator.randomengine
+
+import org.testng.Assert.*
+import org.testng.annotations.Test
+
+class GUIDTest {
+    @Test
+    fun testGUID() {
+        var guid = GUID().guid
+        assertEquals(guid.length.toLong(), GUIDLength)
+    }
+}


### PR DESCRIPTION
Solved issue #46.
IDs are required to simplify implementation of save/load graph functionality.
GUID is a common class is a random String provider.
Tested new functionality and coverage increased.